### PR TITLE
Use workflow input to define Go version in format-go aciton.

### DIFF
--- a/.github/workflows/format-go.yaml
+++ b/.github/workflows/format-go.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: ${{ inputs.go-version }}
           cache: true
 
       - name: Lint


### PR DESCRIPTION
The `format-go.yaml` workflow defines the `go-version` input, but it is not used when calling the `go-setup` action in its list of jobs.

This PR updates the `go-setup` call to use the workflow input value.