### PR TITLE
Increase timeout on Lint job

### DIFF
--- a/.github/workflows/format-go.yaml
+++ b/.github/workflows/format-go.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout=3m
   vet:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When running the `lint` job on `cloudsim`, it timeouts because it takes more than 1 minute to process the source code. This PR increases the timeout to 3 min.